### PR TITLE
RIDER-172 RNNaverMapViewContainer NullPointerException

### DIFF
--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapViewContainer.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapViewContainer.java
@@ -16,6 +16,7 @@ import com.naver.maps.geometry.LatLng;
 import com.naver.maps.geometry.LatLngBounds;
 import com.naver.maps.map.NaverMap;
 import com.naver.maps.map.NaverMapOptions;
+import com.naver.maps.map.UiSettings;
 import com.naver.maps.map.util.FusedLocationSource;
 
 public class RNNaverMapViewContainer extends FrameLayout implements RNNaverMapViewProps {
@@ -53,7 +54,13 @@ public class RNNaverMapViewContainer extends FrameLayout implements RNNaverMapVi
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
-        if (mapView != null && mapView.getMap().getUiSettings().isScrollGesturesEnabled()) {
+        NaverMap map = null;
+        if(this.mapView != null) map = this.mapView.getMap();
+
+        UiSettings uiSettings = null;
+        if(map != null) uiSettings = map.getUiSettings();
+
+        if (uiSettings != null && uiSettings.isScrollGesturesEnabled()) {
             switch (ev.getAction()) {
                 case MotionEvent.ACTION_DOWN:
                 case MotionEvent.ACTION_UP:


### PR DESCRIPTION
### 1. 이슈 링크
- [RIDER-172]

### 2. 핵심 고려사항
1. Firebase에서 급증하는 문제로 종종 보고됨.
2. RNNaverMapViewContainer.dispatchTouchEvent에서 NullPointerException 발생함
3. Optional 사용하기에는 Min Target이 너무 낮음 

### 3. 소스 테스트 방법
1. project를 clone
2. kickoging-app소스에서 package.json를 연다
3. package.json에서 naver로 검색
4. "react-native-nmap": "file:{react-native-navier-map의 상대경로}
> * ex) "react-native-nmap": "file:../../../npm/react-native-naver-map",
5. yarn install
6. Android에서 앱 실행

### 4. 기능 테스트 방법
1. 앱내 맵에서 스크롤, 터치 등으로 죽거나 이상현상 발생하는지 확인

### 5. 기타
Crash Log에서 아래 로그가 반복됨. 무한 루프인지 View 계층에 따른 호출인지 모르겠음.

android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3535)
android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3535)
android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3535)
android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)

### 6. 스크린 샷 (UI 작업일 경우 첨부)
없음

[RIDER-172]: https://olulo.atlassian.net/browse/RIDER-172