### PR TITLE
RIDER-2026 NullPointerException 무시

### DIFF
--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapViewContainer.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapViewContainer.java
@@ -63,7 +63,7 @@ public class RNNaverMapViewContainer extends FrameLayout implements RNNaverMapVi
                         break;
                 }
             }
-        } catch(Error error) { }
+        } catch(NullPointerException e) { }
 
         return super.dispatchTouchEvent(ev);
     }


### PR DESCRIPTION
[RIDER-2026]
catch(Error error)해도 발생해서
NullPointerException 직접 지정으로 바꿔봄.

[RIDER-2026]: https://olulo.atlassian.net/browse/RIDER-2026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

yarn.lock을 업데이트 안해서 그런 것일 수도 있을 것 같다.
react-native-nmap@team-olulo/react-native-naver-map#ios-logo-margin:
  version "0.0.62"
  resolved "https://codeload.github.com/

재설치하면 이게 업데이트 됨