### PR TITLE
getMetersPerDp Method 추가

### DIFF
--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapJavaModule.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapJavaModule.java
@@ -1,7 +1,9 @@
 package com.github.quadflask.react.navermap;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
 
 public class RNNaverMapJavaModule extends ReactContextBaseJavaModule {
 
@@ -14,6 +16,11 @@ public class RNNaverMapJavaModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return REACT_CLASS;
+    }
+
+    @ReactMethod
+    public void getMetersPerDp(final double latitude, final double zoom, final Promise promise) {
+        promise.resolve(RNNaverMapViewContainer.getMetersPerDp(latitude, zoom));
     }
 }
 

--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapView.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapView.java
@@ -327,4 +327,8 @@ public class RNNaverMapView extends MapView implements OnMapReadyCallback, Naver
     public NaverMap getMap() {
         return naverMap;
     }
+
+    public static double getMetersPerDp(double latitude, double zoom) {
+        return Projection.getMetersPerDp(latitude, zoom);
+    }
 }

--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapViewContainer.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapViewContainer.java
@@ -16,6 +16,7 @@ import com.naver.maps.geometry.LatLng;
 import com.naver.maps.geometry.LatLngBounds;
 import com.naver.maps.map.NaverMap;
 import com.naver.maps.map.NaverMapOptions;
+import com.naver.maps.map.Projection;
 import com.naver.maps.map.UiSettings;
 import com.naver.maps.map.util.FusedLocationSource;
 
@@ -298,5 +299,9 @@ public class RNNaverMapViewContainer extends FrameLayout implements RNNaverMapVi
         if (mapView != null)
             return mapView.getFeatureAt(index);
         return null;
+    }
+
+    public static double getMetersPerDp(double latitude, double zoom) {
+        return RNNaverMapView.getMetersPerDp(latitude, zoom);
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { findNodeHandle, Image, NativeModules, Platform, processColor, requireNativeComponent, UIManager, } from 'react-native';
 const RNNaverMapView = requireNativeComponent('RNNaverMapView');
+const RNNaverMapViewModule = NativeModules?.RNNaverMapView
 // @ts-ignore
 const RNNaverMapViewTexture = Platform.select({
     android: () => requireNativeComponent('RNNaverMapViewTexture'),
@@ -107,6 +108,14 @@ export default class NaverMapView extends Component {
         };
         this.handleOnCameraChange = (event) => this.props.onCameraChange && this.props.onCameraChange(event.nativeEvent);
         this.handleOnMapClick = (event) => this.props.onMapClick && this.props.onMapClick(event.nativeEvent);
+        this.getMetersPerDp = async (latitude, zoom) => {
+            const _getMetersPerDp = Platform.select({ 
+                android: () => RNNaverMapViewModule?.getMetersPerDp(latitude, zoom), 
+                ios: () => RNNaverMapViewModule?.getMetersPerDp(this.nodeHandle, latitude, zoom)  
+            })
+    
+            return _getMetersPerDp()
+        };
     }
     render() {
         const { onInitialized, center, tilt, bearing, mapPadding, logoMargin, nightMode, useTextureView, } = this.props;

--- a/index.tsx
+++ b/index.tsx
@@ -1,5 +1,7 @@
 import React, {Component, SyntheticEvent} from 'react';
 import {findNodeHandle, Image, ImageSourcePropType, NativeModules, Platform, processColor, requireNativeComponent, StyleProp, UIManager, ViewStyle,} from 'react-native';
+// import { NativeModules } from 'react-native';
+// module.exports = NativeModules.ToastExample;
 
 const RNNaverMapView = requireNativeComponent('RNNaverMapView');
 // @ts-ignore
@@ -123,6 +125,8 @@ export interface NaverMapViewProps {
     useTextureView?: boolean;
 }
 
+const RNNaverMapViewModule = NativeModules?.RNNaverMapView
+
 export default class NaverMapView extends Component<NaverMapViewProps, {}> {
     ref?: RNNaverMapView;
     nodeHandle?: null | number;
@@ -131,6 +135,15 @@ export default class NaverMapView extends Component<NaverMapViewProps, {}> {
         this.ref = ref;
         this.nodeHandle = findNodeHandle(ref);
     };
+
+    getMetersPerDp = async (latitude: number, zoom: number): Promise<number> => {
+        const _getMetersPerDp = Platform.select({ 
+            android: () => RNNaverMapViewModule?.getMetersPerDp(latitude, zoom), 
+            ios: () => RNNaverMapViewModule?.getMetersPerDp(this.nodeHandle, latitude, zoom)  
+        })
+
+        return _getMetersPerDp()
+    }
 
     animateToCoordinate = (coord: Coord) => {
         this.dispatchViewManagerCommand('animateToCoordinate', [coord]);

--- a/ios/reactNativeNMap/RNNaverMapViewManager.m
+++ b/ios/reactNativeNMap/RNNaverMapViewManager.m
@@ -12,6 +12,7 @@
 #import <NMapsMap/NMFNaverMapView.h>
 #import <NMapsMap/NMFCameraUpdate.h>
 #import <NMapsMap/NMFCameraPosition.h>
+#import <NMapsMap/NMFProjection.h>
 #import <NMapsMap/NMGLatLng.h>
 
 #import "RCTConvert+NMFMapView.h"
@@ -279,6 +280,26 @@ RCT_EXPORT_METHOD(animateToRegion:(nonnull NSNumber *)reactTag
                                        padding: 0.0f];
       cameraUpdate.animation = NMFCameraUpdateAnimationEaseIn;
       [((RNNaverMapView *)view).mapView moveCamera: cameraUpdate];
+    }
+  }];
+}
+
+RCT_EXPORT_METHOD(getMetersPerDp: (nonnull NSNumber *)reactTag
+                  latitude: (double)latitude
+                               zoom: (double) zoom
+                                getMetersPerDpWithResolver: (RCTPromiseResolveBlock)resolve
+                               rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    id view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[RNNaverMapView class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting NMFMapView, got: %@", view);
+    } else {
+        NMFMapView *mapView = ((RNNaverMapView *)view).mapView;
+        NMFProjection *projection = mapView.projection;
+        NSNumber *meters = [NSNumber numberWithDouble: [projection metersPerPixelAtLatitude: latitude zoom: zoom]];
+        
+        resolve(meters);
     }
   }];
 }


### PR DESCRIPTION
[작업 목적]
- [RIDER-2705]
해당 Zoom Level의 dp(pt) 당 실제 거리를 구하기 위함

[작업 내용]
- Android에 getMetersPerDp ReactMethod 추가
> - Projection.getMetersPerDp 호출
- iOS에 getMetersPerDp 추가
> - dp는 Android에서만 사용되는 개념이다 내부적으로는 projection.metersPerPixelAtLatitude가 호출됨

[기타]
- Android는 Projection Class의 static 메소드가 제공되지만 iOS는 projection 멤버 메소드만 제공되어서 내부적으로 view를 찾는 코드가 포함된다

[RIDER-2705]: https://olulo.atlassian.net/browse/RIDER-2705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ