### PR TITLE
circle overlay 에서도 클릭 감지하도록 수정

### DIFF
--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapCircleOverlay.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapCircleOverlay.java
@@ -3,12 +3,21 @@ package com.github.quadflask.react.navermap;
 import android.content.Context;
 
 import com.naver.maps.geometry.LatLng;
+import com.naver.maps.map.overlay.Overlay;
 import com.naver.maps.map.overlay.CircleOverlay;
+
+import androidx.annotation.NonNull;
 
 public class RNNaverMapCircleOverlay extends ClickableRNNaverMapFeature<CircleOverlay> {
     public RNNaverMapCircleOverlay(EventEmittable emitter, Context context) {
         super(emitter, context);
         feature = new CircleOverlay();
+    }
+
+    @Override
+    public boolean onClick(@NonNull Overlay overlay) {
+        emitEvent("onClick", null);
+        return false;
     }
 
     public void setCenter(LatLng center) {


### PR DESCRIPTION
[RIDER-2752]

ios에선 잘되는데, android에서 naver map circle 터치 시 onMapClick 콜백함수가 실행되지 않아서 수정함

[RIDER-2752]: https://olulo.atlassian.net/browse/RIDER-2752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ