### PR TITLE
RIDER-2667 Adds pattern, capType Prop of Polyline for Typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,11 @@ export declare enum Align {
     BottomRight = 7,
     BottomLeft = 8
 }
+export declare enum LineCap {
+    Round = 0 ,
+    Butt = 1,
+    Square = 2,
+}
 export interface Rect {
     left?: number;
     top?: number;
@@ -217,6 +222,8 @@ interface PolylineProps extends Omit<MapOverlay, "coordinate"> {
     coordinates: Coord[];
     strokeWidth?: number;
     strokeColor?: string;
+    pattern?: number[];
+    capType?: LineCap;
 }
 export declare class Polyline extends Component<PolylineProps> {
     render(): JSX.Element;

--- a/ios/reactNativeNMap/RNNaverMapPolylineOverlay.h
+++ b/ios/reactNativeNMap/RNNaverMapPolylineOverlay.h
@@ -20,6 +20,8 @@
 @property (nonatomic, assign) NSArray<NMGLatLng *> *coordinates;
 @property (nonatomic, assign) CGFloat strokeWidth;
 @property (nonatomic, strong) UIColor *strokeColor;
+@property (nonatomic, strong) NSArray<NSNumber *> *pattern;
+@property (nonatomic, assign) NMFOverlayLineCap capType;
 @property (nonatomic, copy) RCTDirectEventBlock onClick;
 
 @end

--- a/ios/reactNativeNMap/RNNaverMapPolylineOverlay.m
+++ b/ios/reactNativeNMap/RNNaverMapPolylineOverlay.m
@@ -47,4 +47,12 @@
   _realOverlay.color = strokeColor;
 }
 
+- (void)setPattern:(NSArray<NSNumber *> *_Nonnull) pattern {
+  _realOverlay.pattern = pattern;
+}
+
+- (void)setCapType:(NMFOverlayLineCap) capType {
+  _realOverlay.capType = capType;
+}
+
 @end

--- a/ios/reactNativeNMap/RNNaverMapPolylineOverlayManager.m
+++ b/ios/reactNativeNMap/RNNaverMapPolylineOverlayManager.m
@@ -34,6 +34,8 @@ RCT_CUSTOM_VIEW_PROPERTY(coordinates, NSArray<NMGLatLng*>, RNNaverMapPolylineOve
 }
 RCT_EXPORT_VIEW_PROPERTY(strokeWidth, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(strokeColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(pattern, NSNumberArray)
+RCT_EXPORT_VIEW_PROPERTY(capType, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(onClick, RCTDirectEventBlock)
 
 @end


### PR DESCRIPTION
[개요]
[RIDER-2667] Native Polyline에서 제공하는 pattern, capType property를 사용하기 위해 수정

[작업 내용]
1. Native 쪽 Bridge에는 이미 해당 Prop이 구현되어있음
2. Javascript는 전체 props를 넘기게 되어있음
3. Typescript에서만 해당 Property들이 빠져있어서 추가
4. iOS bridge 없음... 구현 필요

[테스트 방법]
- Polyline 사용할 때 아래와 같이 사용
```
pattern={[12, 6]}
capType={2}
```

[적용 예]
![polyline-dash-12-4d](https://user-images.githubusercontent.com/85471652/151288125-13f99036-848b-409c-bb8b-38e12960c50f.png)

[RIDER-2667]: https://olulo.atlassian.net/browse/RIDER-2667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ