### PR TITLE
PD-841 info에 color 지정하지 않으면 죽는 문제

### DIFF
--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapMarkerManager.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapMarkerManager.java
@@ -156,13 +156,13 @@ public class RNNaverMapMarkerManager extends EventEmittableViewGroupManager<RNNa
         boolean isVisible = map.hasKey("visible") ? map.getBoolean("visible") : true;
         String text = map.hasKey("text") ? map.getString("text") : null;
         Double textSize = map.hasKey("textSize") ? map.getDouble("textSize") : null;
-        int color = map.hasKey("color") ? parseColorString(map.getString("color")) : null;
+        Integer color = map.hasKey("color") ? parseColorString(map.getString("color")) : null;
         boolean multiline = map.hasKey("multiline") ? map.getBoolean("multiline") : false;
-        int maxWidth = map.hasKey("maxWidth") ? map.getInt("maxWidth") : null;
-        int backgroundColor = map.hasKey("backgroundColor") ? parseColorString(map.getString("backgroundColor")) : null;
-        int paddingHorizental = map.hasKey("paddingHorizental") ? map.getInt("paddingHorizental") : 0;
-        int paddingVertical = map.hasKey("paddingVertical") ? map.getInt("paddingVertical") : 0;
-        int cornerRadius = map.hasKey("cornerRadius") ? map.getInt("cornerRadius") : 8;
+        Integer maxWidth = map.hasKey("maxWidth") ? map.getInt("maxWidth") : null;
+        Integer backgroundColor = map.hasKey("backgroundColor") ? parseColorString(map.getString("backgroundColor")) : null;
+        Integer paddingHorizental = map.hasKey("paddingHorizental") ? map.getInt("paddingHorizental") : 0;
+        Integer paddingVertical = map.hasKey("paddingVertical") ? map.getInt("paddingVertical") : 0;
+        Integer cornerRadius = map.hasKey("cornerRadius") ? map.getInt("cornerRadius") : 8;
 
         RNNaverMapInfoWindow infoWindow = view.getInfoWindow();
         boolean hasInfoWindow = false;

--- a/index.d.ts
+++ b/index.d.ts
@@ -198,7 +198,7 @@ export interface MarkerProps extends MapOverlay {
         maxWidth?: number;
         paddingHorizental?: number;
         paddingVertical?: number;
-        cornerRadius: number;
+        cornerRadius?: number;
     };
     style?: StyleProp<ViewStyle>;
 }

--- a/index.tsx
+++ b/index.tsx
@@ -302,7 +302,7 @@ export interface MarkerProps extends MapOverlay {
         maxWidth?: number;
         paddingHorizental?: number;
         paddingVertical?: number;
-        cornerRadius: number
+        cornerRadius?: number
     };
     style?: StyleProp<ViewStyle>;
 }


### PR DESCRIPTION
[작업 개요]
- [PD-841]
- cornerRadius optional로 변경(문법 오류)

[원인]
- int에 null이 대입되면 죽는 것으로 추정

[오류]
![Screenshot_20221214_125504](https://user-images.githubusercontent.com/85471652/207503619-4c88e592-7169-4660-9e8d-d2b41f48e8f4.png)

[PD-841]: https://olulo.atlassian.net/browse/PD-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ