### PR TITLE
PD-948 infoWindow zIndex 설정 지원

### DIFF
--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapInfoWindow.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapInfoWindow.java
@@ -21,6 +21,8 @@ public class RNNaverMapInfoWindow {
     Integer paddingHorizental = 0;
     Integer paddingVertical = 0;
     Integer cornerRadius = 8;
+    Integer zIndex;
+    Integer globalZIndex;
 
     InfoWindow.ViewAdapter adapter;
 
@@ -103,6 +105,26 @@ public class RNNaverMapInfoWindow {
 
         this.cornerRadius = value;
         return this;
+    }
+
+    public RNNaverMapInfoWindow setZIndex(Integer value) {
+        if (value == null) return this;
+
+        this.zIndex = value;
+        this.applyZIndex(value);
+        return this;
+    }
+
+    public RNNaverMapInfoWindow setGlobalZIndex(Integer value) {
+        if (value == null) return this;
+
+        this.globalZIndex = value;
+        this.infoWindow.setGlobalZIndex(value);
+        return this;
+    }
+
+    public void applyZIndex(int value) {
+        this.infoWindow.setZIndex(value);
     }
 
     public void open() {

--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapMarker.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapMarker.java
@@ -130,6 +130,10 @@ public class RNNaverMapMarker extends ClickableRNNaverMapFeature<Marker> impleme
 
     public void setZIndex(int zIndex) {
         feature.setZIndex(zIndex);
+
+        if (this.infoWindow != null && this.infoWindow.zIndex == null) {
+            this.infoWindow.applyZIndex(feature.getZIndex());
+        }
     }
 
     public void setAnchor(float x, float y) {

--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapMarkerManager.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapMarkerManager.java
@@ -163,6 +163,8 @@ public class RNNaverMapMarkerManager extends EventEmittableViewGroupManager<RNNa
         Integer paddingHorizental = map.hasKey("paddingHorizental") ? map.getInt("paddingHorizental") : 0;
         Integer paddingVertical = map.hasKey("paddingVertical") ? map.getInt("paddingVertical") : 0;
         Integer cornerRadius = map.hasKey("cornerRadius") ? map.getInt("cornerRadius") : 8;
+        Integer zIndex = map.hasKey("zIndex") ? map.getInt("zIndex") : null;
+        Integer globalZIndex = map.hasKey("globalZIndex") ? map.getInt("globalZIndex") : null;
 
         RNNaverMapInfoWindow infoWindow = view.getInfoWindow();
         boolean hasInfoWindow = false;
@@ -181,7 +183,9 @@ public class RNNaverMapMarkerManager extends EventEmittableViewGroupManager<RNNa
                 .setMaxWidth(maxWidth)
                 .setPaddingHorizental(paddingHorizental)
                 .setPaddingVertical(paddingVertical)
-                .setCornerRadius(cornerRadius);
+                .setCornerRadius(cornerRadius)
+                .setZIndex(zIndex)
+                .setGlobalZIndex(globalZIndex);
 
         if (hasInfoWindow) {
             if (isVisible && !infoWindow.isVisible) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -211,6 +211,8 @@ export interface MarkerProps extends MapOverlay {
         paddingHorizental?: number;
         paddingVertical?: number;
         cornerRadius?: number;
+        zIndex?: number;
+        globalZIndex?: number;
     };
     style?: StyleProp<ViewStyle>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,18 @@ export declare enum Align {
     BottomRight = 7,
     BottomLeft = 8
 }
+export declare const NaverMapGlobalIndexes: {
+    infoWindow: number;
+    location: number;
+    marker: number;
+    arrow: number;
+    /** 경로선 */
+    path: number;
+    /** 셰이프(폴리곤, 폴리라인, 서클) */
+    shape: number;
+    /** 지상 */
+    ground: number;
+};
 export interface Rect {
     left?: number;
     top?: number;

--- a/index.js
+++ b/index.js
@@ -73,6 +73,18 @@ export var Align;
     Align[Align["BottomRight"] = 7] = "BottomRight";
     Align[Align["BottomLeft"] = 8] = "BottomLeft";
 })(Align || (Align = {}));
+export const NaverMapGlobalIndexes = {
+    infoWindow: 400000,
+    location: 300000,
+    marker: 200000,
+    arrow: 100000,
+    /** 경로선 */
+    path: -100000,
+    /** 셰이프(폴리곤, 폴리라인, 서클) */
+    shape: -200000,
+    /** 지상 */
+    ground: -300000
+};
 const RNNaverMapViewModule = NativeModules.RNNaverMapView;
 export default class NaverMapView extends Component {
     constructor() {

--- a/index.tsx
+++ b/index.tsx
@@ -316,6 +316,8 @@ export interface MarkerProps extends MapOverlay {
         paddingHorizental?: number;
         paddingVertical?: number;
         cornerRadius?: number
+        zIndex?: number
+        globalZIndex?: number
     };
     style?: StyleProp<ViewStyle>;
 }

--- a/index.tsx
+++ b/index.tsx
@@ -76,6 +76,19 @@ export enum Align {
     BottomLeft,
 }
 
+export const NaverMapGlobalIndexes = {
+    infoWindow: 400000,
+    location: 300000,
+    marker: 200000,
+    arrow: 100000,
+    /** 경로선 */
+    path: -100000,
+    /** 셰이프(폴리곤, 폴리라인, 서클) */
+    shape:  -200000,
+    /** 지상 */
+    ground: -300000
+}
+
 export interface Rect {
     left?: number;
     top?: number;


### PR DESCRIPTION
[PD-948]
[작업 내용]
- zIndex
> -  지정하지 않으면 마커 따라감
- globalZIndex  설정 지원
> - 기본적으로 정보 창이 마커보다 상위 값이라 강제로 조정하지 않으면 마커가 정보 창 위로 올라올 수가 없음

<img width="814" alt="스크린샷 2022-12-21 오후 4 37 22" src="https://user-images.githubusercontent.com/85471652/208847444-1c1363d7-5540-4cfe-8289-8fef66032d72.png">

[스크린샷]
![Screenshot_20221221_152914](https://user-images.githubusercontent.com/85471652/208847090-9b8878bc-f21a-4073-b16e-442ea55ec3c3.png)


[PD-948]: https://olulo.atlassian.net/browse/PD-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ