### PR TITLE
PD-1048 iOS infoWindow 선택 버그 수정

### DIFF
--- a/ios/reactNativeNMap/RNNaverMapInfoWindow.m
+++ b/ios/reactNativeNMap/RNNaverMapInfoWindow.m
@@ -47,7 +47,7 @@
 
         marker.onClick(@{});
 
-        return false;
+        return true;
     };
 }
 


### PR DESCRIPTION
[PD-1048]

[작업개요]
- iOS에서 infoWindow를 선택하면 infoWindow가 click되자마자 맵의 click도 호출되서 선택이 풀리는 문제 발생

[작업내용]
- infoWindow 선택이벤트 처리했다고 지정해서 맵에 event가 전파되지 않게 수정

[PD-1048]: https://olulo.atlassian.net/browse/PD-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ