### PR TITLE
PD-1144 infoWindow 말줄임 시 공백 생기는 버그 수정

### DIFF
--- a/ios/reactNativeNMap/RNNaverMapInfoWindow.h
+++ b/ios/reactNativeNMap/RNNaverMapInfoWindow.h
@@ -49,6 +49,9 @@
 @property (nonatomic, strong) NSLayoutConstraint *topContaraint;
 @property (nonatomic, strong) NSLayoutConstraint *bottomContaraint;
 
+@property (nonatomic, copy) NSString *ellipsizedText;
+@property (nonatomic, assign) CGFloat ellipsizeTextWidth;
+
 - (void)setIsVisible:(BOOL) value;
 - (void)setText:(NSString *) value;
 - (void)setTextSize:(CGFloat) value;


### PR DESCRIPTION
[PD-1144]

[작업개요]
- 말줄임 끝에 공백이 추가되는 경우가 있음

[작업내용]
- native 둘다 발생
> - native에서 말줄임 붙인 후 계산 방식의 문제인듯, 한글만의 문제도 아님
- 기본 말줌임 사용하는 대신 직접 크기를 계산해서 ...를 붙임
> - maxWidth를 설정하지 않음, 계산에서만 사용

[스크린샷]
![Screen Shot 2023-01-06 at 1 30 31 PM](https://user-images.githubusercontent.com/85471652/210930642-9f5d3800-43db-4fce-a6e7-d3c4a175bd47.png)


[PD-1144]: https://olulo.atlassian.net/browse/PD-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ