### PR TITLE
PD-1201 Android에서 NaverMap 멈춤 이벤트 호출 제한 100ms로 조정

### DIFF
--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapView.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapView.java
@@ -35,7 +35,7 @@ public class RNNaverMapView extends MapView implements OnMapReadyCallback, Naver
     private ViewAttacherGroup2 attacherGroup;
     private long lastTouch = 0;
     private long lastMoved = 0;
-    private final long IdleThreshold = 500;
+    private final long IdleThreshold = 100;
     private int lastMovingReason = REASON_DEVELOPER;
     void updateLastMovingReason(int reason) {
         this.lastMovingReason = reason;
@@ -301,8 +301,9 @@ public class RNNaverMapView extends MapView implements OnMapReadyCallback, Naver
     boolean canCallCameraIdleEvent() {
         long now = this.now();
         if (this.movingStarted == 0) return false;
+        if (this.lastMovingReason != REASON_GESTURE) return true;
 
-        return this.now() - this.movingStarted > IdleThreshold;
+        return now - this.movingStarted > IdleThreshold;
     }
 
     @Override


### PR DESCRIPTION
[PD-1201]

[작업개요]
[PD-1174] 처리를 위해 추가
- 내 위치 이동 후 지도 멈춤 감지되지 않는 문제

[작업내용]
- 호출 제한 100ms로 조정
- Gesture로 이동한 경우만 제한하게 수정

[PD-1201]: https://olulo.atlassian.net/browse/PD-1201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PD-1174]: https://olulo.atlassian.net/browse/PD-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ